### PR TITLE
Fix static template error and add reusable snippets

### DIFF
--- a/docport/portal/templates/portal/base.html
+++ b/docport/portal/templates/portal/base.html
@@ -1,25 +1,31 @@
 <!DOCTYPE html>
+{% load static %}
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Documentation Portal</title>
+    <title>{% block title %}Documentation Portal{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'portal/style.css' %}">
 </head>
 <body>
 <header>
-    <h1>Documentation Portal</h1>
+    {% block logo %}{% include 'portal/snippets/logo.html' %}{% endblock %}
+    {% block user_badge %}{% include 'portal/snippets/user_badge.html' %}{% endblock %}
 </header>
+
 <nav>
-    <ul>
-        <li><a href="#">Version 1</a></li>
-        <li><a href="#">Version 2</a></li>
-    </ul>
+    {% block menu_bar %}{% include 'portal/snippets/menu_bar.html' %}{% endblock %}
 </nav>
+
+<div class="sidebar">
+    {% block sidebar %}{% include 'portal/snippets/sidebar.html' %}{% endblock %}
+</div>
+
 <main>
     {% block content %}{% endblock %}
 </main>
+
 <footer>
-    <p>&copy; 2024 Documentation Portal</p>
+    {% block footer %}{% include 'portal/snippets/footer.html' %}{% endblock %}
 </footer>
 </body>
 </html>

--- a/docport/portal/templates/portal/index.html
+++ b/docport/portal/templates/portal/index.html
@@ -3,4 +3,5 @@
 {% block content %}
 <h2>Welcome to the Documentation Portal</h2>
 <p>Select a version to read SOPs, standards, and articles.</p>
+{% include 'portal/snippets/about_us.html' %}
 {% endblock %}

--- a/docport/portal/templates/portal/snippets/about_us.html
+++ b/docport/portal/templates/portal/snippets/about_us.html
@@ -1,0 +1,4 @@
+<section class="about-us">
+    <h2>About Us</h2>
+    <p>This portal hosts documentation for various versions.</p>
+</section>

--- a/docport/portal/templates/portal/snippets/common_menu_list.html
+++ b/docport/portal/templates/portal/snippets/common_menu_list.html
@@ -1,0 +1,3 @@
+<li><a href="#">Home</a></li>
+<li><a href="#">Docs</a></li>
+<li><a href="#">About Us</a></li>

--- a/docport/portal/templates/portal/snippets/footer.html
+++ b/docport/portal/templates/portal/snippets/footer.html
@@ -1,0 +1,1 @@
+<p>&copy; 2024 Documentation Portal</p>

--- a/docport/portal/templates/portal/snippets/logo.html
+++ b/docport/portal/templates/portal/snippets/logo.html
@@ -1,0 +1,3 @@
+<div class="logo">
+    <h1>Documentation Portal</h1>
+</div>

--- a/docport/portal/templates/portal/snippets/menu_bar.html
+++ b/docport/portal/templates/portal/snippets/menu_bar.html
@@ -1,0 +1,3 @@
+<ul>
+    {% include 'portal/snippets/common_menu_list.html' %}
+</ul>

--- a/docport/portal/templates/portal/snippets/sidebar.html
+++ b/docport/portal/templates/portal/snippets/sidebar.html
@@ -1,0 +1,7 @@
+<aside>
+    <h2>Sidebar</h2>
+    <ul>
+        <li><a href="#">Link 1</a></li>
+        <li><a href="#">Link 2</a></li>
+    </ul>
+</aside>

--- a/docport/portal/templates/portal/snippets/user_badge.html
+++ b/docport/portal/templates/portal/snippets/user_badge.html
@@ -1,0 +1,3 @@
+<div class="user-badge">
+    <p>User: Guest</p>
+</div>


### PR DESCRIPTION
## Summary
- load the static template tag and introduce common blocks in `base.html`
- add various snippet templates for reusable UI pieces
- show an example in `index.html`

## Testing
- `python docport/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68487893bcdc833384d82cf6e3ca88ba