### PR TITLE
Implement login page with placeholder social logins

### DIFF
--- a/docport/portal/templates/portal/login.html
+++ b/docport/portal/templates/portal/login.html
@@ -1,0 +1,20 @@
+{% extends 'portal/base.html' %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Sign in</button>
+</form>
+
+<div class="social-logins">
+    <p>You can also sign in using:</p>
+    <ul>
+        <li><a href="#">Google</a> (placeholder)</li>
+        <li><a href="#">Microsoft</a> (placeholder)</li>
+    </ul>
+</div>
+{% endblock %}

--- a/docport/portal/templates/portal/snippets/user_badge.html
+++ b/docport/portal/templates/portal/snippets/user_badge.html
@@ -1,3 +1,7 @@
 <div class="user-badge">
-    <p>User: Guest</p>
+    {% if request.user.is_authenticated %}
+        <p>User: {{ request.user.username }} (<a href="{% url 'logout' %}">logout</a>)</p>
+    {% else %}
+        <p><a href="{% url 'login' %}">Login</a></p>
+    {% endif %}
 </div>

--- a/docport/portal/urls.py
+++ b/docport/portal/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
+from django.contrib.auth import views as auth_views
 from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('accounts/login/', auth_views.LoginView.as_view(template_name='portal/login.html'), name='login'),
+    path('accounts/logout/', auth_views.LogoutView.as_view(), name='logout'),
 ]

--- a/docport/system/settings.py
+++ b/docport/system/settings.py
@@ -121,3 +121,7 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Redirect users to the portal index after successful login or logout
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'


### PR DESCRIPTION
## Summary
- add login and logout endpoints
- include login template and user badge updates
- redirect users to index after auth actions

## Testing
- `python docport/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68488164d864833394679766c1f9f109