### PR TITLE
Add article creation and editing features

### DIFF
--- a/docport/portal/admin.py
+++ b/docport/portal/admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+from .models import Article, Comment
+
+
+@admin.register(Article)
+class ArticleAdmin(admin.ModelAdmin):
+    list_display = ('title', 'author', 'published_at')
+    search_fields = ('title', 'content')
+    list_filter = ('published_at',)
+
+
+@admin.register(Comment)
+class CommentAdmin(admin.ModelAdmin):
+    list_display = ('article', 'author', 'created_at')
+    search_fields = ('text',)
+    list_filter = ('created_at',)

--- a/docport/portal/forms.py
+++ b/docport/portal/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+from .models import Article
+
+
+class ArticleForm(forms.ModelForm):
+    class Meta:
+        model = Article
+        fields = ['title', 'content']

--- a/docport/portal/migrations/0001_initial.py
+++ b/docport/portal/migrations/0001_initial.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Article',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=200)),
+                ('content', models.TextField()),
+                ('published_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('author', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Comment',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('text', models.TextField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('article', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='comments', to='portal.article')),
+                ('author', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/docport/portal/models.py
+++ b/docport/portal/models.py
@@ -1,0 +1,23 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+
+class Article(models.Model):
+    title = models.CharField(max_length=200)
+    content = models.TextField()
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    published_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.title
+
+
+class Comment(models.Model):
+    article = models.ForeignKey(Article, related_name='comments', on_delete=models.CASCADE)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    text = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"Comment by {self.author} on {self.article}"

--- a/docport/portal/templates/portal/article_form.html
+++ b/docport/portal/templates/portal/article_form.html
@@ -1,0 +1,10 @@
+{% extends 'portal/base.html' %}
+
+{% block content %}
+<h2>{% if article %}Edit{% else %}Add{% endif %} Article</h2>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/docport/portal/templates/portal/article_list.html
+++ b/docport/portal/templates/portal/article_list.html
@@ -1,0 +1,17 @@
+{% extends 'portal/base.html' %}
+
+{% block content %}
+<h2>Articles</h2>
+<p><a href="{% url 'article_create' %}">Add Article</a></p>
+<ul>
+    {% for article in articles %}
+    <li>
+        <h3>{{ article.title }}</h3>
+        <p>by {{ article.author }} on {{ article.published_at|date:"Y-m-d H:i" }}</p>
+        <a href="{% url 'article_edit' article.pk %}">Edit</a>
+    </li>
+    {% empty %}
+    <li>No articles yet.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/docport/portal/templates/portal/snippets/common_menu_list.html
+++ b/docport/portal/templates/portal/snippets/common_menu_list.html
@@ -1,3 +1,4 @@
 <li><a href="#">Home</a></li>
 <li><a href="#">Docs</a></li>
 <li><a href="#">About Us</a></li>
+<li><a href="{% url 'article_list' %}">Articles</a></li>

--- a/docport/portal/urls.py
+++ b/docport/portal/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path
+
 from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('articles/', views.article_list, name='article_list'),
+    path('articles/create/', views.article_create, name='article_create'),
+    path('articles/<int:pk>/edit/', views.article_edit, name='article_edit'),
 ]

--- a/docport/portal/views.py
+++ b/docport/portal/views.py
@@ -1,5 +1,41 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404, redirect
+from django.contrib.auth.decorators import login_required
+
+from .models import Article
+from .forms import ArticleForm
 
 
 def index(request):
     return render(request, 'portal/index.html')
+
+
+def article_list(request):
+    articles = Article.objects.order_by('-published_at')
+    return render(request, 'portal/article_list.html', {'articles': articles})
+
+
+@login_required
+def article_create(request):
+    if request.method == 'POST':
+        form = ArticleForm(request.POST)
+        if form.is_valid():
+            article = form.save(commit=False)
+            article.author = request.user
+            article.save()
+            return redirect('article_list')
+    else:
+        form = ArticleForm()
+    return render(request, 'portal/article_form.html', {'form': form})
+
+
+@login_required
+def article_edit(request, pk):
+    article = get_object_or_404(Article, pk=pk)
+    if request.method == 'POST':
+        form = ArticleForm(request.POST, instance=article)
+        if form.is_valid():
+            form.save()
+            return redirect('article_list')
+    else:
+        form = ArticleForm(instance=article)
+    return render(request, 'portal/article_form.html', {'form': form, 'article': article})


### PR DESCRIPTION
## Summary
- create `Article` and `Comment` models
- register the models in admin
- add `ArticleForm`
- implement CRUD views for articles
- expose article URLs and link from menu
- add templates for article list and form
- provide initial migration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848827f9c208333ba9075af5fe37d7d